### PR TITLE
GDALGeoDataset::GetProjectionRef calleded within OMP critical section

### DIFF
--- a/geo/CMakeLists.txt
+++ b/geo/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(geo_VERSION 1.37)
+set(geo_VERSION 1.38)
 
 set(geo_EXTRA_DEPENDS)
 set(geo_EXTRA_DEFINITIONS)


### PR DESCRIPTION
When compiled with GDAL<3 an OMP critical section is added around call to GetProjectionRef to work around non-thread-safe `libgeotiff2` loading CSV files into unprotected internal tables.

NB: Critical section name is shared with `librasterio`.
