### PR TITLE
writeSrs: using SrsDefiniotions operator<< to allow proper SRS writing

### DIFF
--- a/geo/io.cpp
+++ b/geo/io.cpp
@@ -19,7 +19,7 @@ void writeSrs( const boost::filesystem::path &path
     std::ofstream f( path.native() );
     f.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
-    f << srs.as(type).srs;
+    f << srs.as(type);
 
     f.close();
 }


### PR DESCRIPTION
Properly writing EPSG SRS with `epsg:` prefix, i.e. `espg:code` or `espg:code+code`.
